### PR TITLE
Fix dependency version bundle and add register bundle to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ public function registerBundles()
 {
     $bundles = array(
         // ...
-        new \WTF\CartBundle\WTFCartBundle(),
+        new WTF\CartBundle\WTFCartBundle(),
+        new Sonata\EasyExtendsBundle\SonataEasyExtendsBundle(),
     );
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.3",	
-	    "symfony/framework-bundle": "2.*",
+	    "symfony/framework-bundle": "2.3.*",
         "gedmo/doctrine-extensions": "2.3.*",
-        "sonata-project/easy-extends-bundle": "2.1.*@dev"
+        "sonata-project/easy-extends-bundle": "2.1.9"
     },
     "autoload": {
         "psr-0": { "WTF\\CartBundle\\": "" }


### PR DESCRIPTION
Fix dependency version bundle : 
- symfony 2.3.*
- sonata-easy-extend : 2.1.9

Add register bundle to README : if bundle no register to AppKernel relation between user / cart and product / cart doesn't work
